### PR TITLE
Enable Vulkan backend for SKIA/HWUI

### DIFF
--- a/aosptree/vendor/devices-community/gd_rpi4/device.mk
+++ b/aosptree/vendor/devices-community/gd_rpi4/device.mk
@@ -67,8 +67,8 @@ PRODUCT_COPY_FILES += \
 PRODUCT_VENDOR_PROPERTIES +=    \
     ro.hardware.vulkan=broadcom \
 
-# It is the only way to set ro.hwui.use_vulkan=true
-#TARGET_USES_VULKAN = true
+# Enable Vulkan backend for SKIA/HWUI
+TARGET_USES_VULKAN = true
 
 # Bluetooth
 PRODUCT_VENDOR_PROPERTIES +=    \

--- a/manifests/glodroid.xml
+++ b/manifests/glodroid.xml
@@ -20,7 +20,7 @@
   <!-- gpu+display components (vendor) -->
   <project path="glodroid/vendor/minigbm"         remote="aosp" name="platform/external/minigbm"        groups="glodroid" revision="84b3a09ef0e620c1b2ec19c7626c327e68a847bc" />
   <project path="glodroid/vendor/drm_hwcomposer"  remote="aosp" name="platform/external/drm_hwcomposer" groups="glodroid" revision="5de61b5e4fbf43b78b605dab68465aa6722930c4" />
-  <project path="glodroid/vendor/mesa3d"          remote="aosp" name="platform/external/mesa3d"         groups="glodroid" revision="refs/tags/upstream-mesa-23.1.5" />
+  <project path="glodroid/vendor/mesa3d"          remote="aosp" name="platform/external/mesa3d"         groups="glodroid" revision="f88338f80127d8bbbb49269e2399fd9e7e460c5c" />
 
   <!-- camera components (vendor) -->
   <project path="glodroid/vendor/libcamera"                     remote="libcamera" name="libcamera.git"      groups="glodroid" revision="960d0c1e19feaf310321c906e14bd5410c6be629" />

--- a/patches-aosp/frameworks/base/0001-Revert-Fix-crash-from-asynchronous-GPU-metrics.patch
+++ b/patches-aosp/frameworks/base/0001-Revert-Fix-crash-from-asynchronous-GPU-metrics.patch
@@ -1,7 +1,7 @@
-From cadc9a7ccb98d6ec38b605ea7088087541de54fb Mon Sep 17 00:00:00 2001
+From 20b679d769451e5690322a72c8feec55e4ef90c1 Mon Sep 17 00:00:00 2001
 From: Roman Stratiienko <r.stratiienko@gmail.com>
 Date: Wed, 29 Mar 2023 20:49:55 +0300
-Subject: [PATCH] Revert "Fix crash from asynchronous GPU metrics"
+Subject: [PATCH 1/4] Revert "Fix crash from asynchronous GPU metrics"
 
 This reverts commit 5d28aee1b1ac76e73db174535802bd2cc6069909.
 
@@ -25,7 +25,7 @@ Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>
  2 files changed, 5 insertions(+), 15 deletions(-)
 
 diff --git a/libs/hwui/FrameInfoVisualizer.cpp b/libs/hwui/FrameInfoVisualizer.cpp
-index 687e4dd324d3..3a8e559f6d7e 100644
+index 687e4dd3..3a8e559f 100644
 --- a/libs/hwui/FrameInfoVisualizer.cpp
 +++ b/libs/hwui/FrameInfoVisualizer.cpp
 @@ -179,7 +179,7 @@ void FrameInfoVisualizer::initializeRects(const int baseline, const int width) {
@@ -38,7 +38,7 @@ index 687e4dd324d3..3a8e559f6d7e 100644
          if (mFrameSource[fi][FrameInfoIndex::Flags] & FrameInfoFlags::SkippedFrame) {
              continue;
 diff --git a/libs/hwui/renderthread/CanvasContext.cpp b/libs/hwui/renderthread/CanvasContext.cpp
-index 75d3ff7753cb..976117b9bbd4 100644
+index f56d19bf..1c84202c 100644
 --- a/libs/hwui/renderthread/CanvasContext.cpp
 +++ b/libs/hwui/renderthread/CanvasContext.cpp
 @@ -512,19 +512,9 @@ nsecs_t CanvasContext::draw() {

--- a/patches-aosp/frameworks/base/0002-Added-forced-orientation-lock.patch
+++ b/patches-aosp/frameworks/base/0002-Added-forced-orientation-lock.patch
@@ -1,7 +1,7 @@
-From 96a33fa31cdf937c1faebc0273f49a1004f585ad Mon Sep 17 00:00:00 2001
+From 0f26ab33feba208b5dacd0f3ff11a2cdbbfa2f0d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
 Date: Tue, 21 Jun 2022 20:08:56 +0200
-Subject: [PATCH 1/3] Added forced orientation lock
+Subject: [PATCH 2/4] Added forced orientation lock
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -13,10 +13,10 @@ Signed-off-by: Michał Gapiński <mike@gapinski.eu>
  1 file changed, 1 insertion(+), 12 deletions(-)
 
 diff --git a/services/core/java/com/android/server/wm/DisplayRotation.java b/services/core/java/com/android/server/wm/DisplayRotation.java
-index e6d8b3db4564..ac5d6273b1bf 100644
+index 0a1e29ac..02f1d5ac 100644
 --- a/services/core/java/com/android/server/wm/DisplayRotation.java
 +++ b/services/core/java/com/android/server/wm/DisplayRotation.java
-@@ -363,18 +363,7 @@ public class DisplayRotation {
+@@ -401,18 +401,7 @@ public class DisplayRotation {
          }
          mDemoRotationLock = SystemProperties.getBoolean("persist.demo.rotationlock", false);
  

--- a/patches-aosp/frameworks/base/0003-Ignore-build-warnings-about-inconsistent-builds.patch
+++ b/patches-aosp/frameworks/base/0003-Ignore-build-warnings-about-inconsistent-builds.patch
@@ -1,7 +1,7 @@
-From 2efa7f56d96481d4cce0ba74ec2f298598166ef4 Mon Sep 17 00:00:00 2001
+From 4a756c1f2c91a55339f189bb99915942e26b3880 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
 Date: Mon, 31 Oct 2022 19:24:53 +0100
-Subject: [PATCH 3/3] Ignore build warnings about inconsistent builds
+Subject: [PATCH 3/4] Ignore build warnings about inconsistent builds
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -12,7 +12,7 @@ Signed-off-by: Michał Gapiński <mike@gapinski.eu>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/core/java/android/os/Build.java b/core/java/android/os/Build.java
-index 0b956f8bf9e0..380129734f59 100755
+index 0b956f8b..38012973 100755
 --- a/core/java/android/os/Build.java
 +++ b/core/java/android/os/Build.java
 @@ -1248,6 +1248,7 @@ public class Build {

--- a/patches-aosp/frameworks/base/0004-Allow-runtime-override-of-hwui.use_vulkan.patch
+++ b/patches-aosp/frameworks/base/0004-Allow-runtime-override-of-hwui.use_vulkan.patch
@@ -1,0 +1,26 @@
+From 27b9a5cb6894fc59b4967c16883b39c13ff84ca8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
+Date: Fri, 22 Sep 2023 14:32:12 +0000
+Subject: [PATCH 4/4] Allow runtime override of hwui.use_vulkan
+
+Change-Id: I30eab5cb525ab5bd863b274c77e6549298cc07be
+---
+ libs/hwui/Properties.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libs/hwui/Properties.cpp b/libs/hwui/Properties.cpp
+index 5a67eb99..41101194 100644
+--- a/libs/hwui/Properties.cpp
++++ b/libs/hwui/Properties.cpp
+@@ -36,7 +36,7 @@ namespace uirenderer {
+ 
+ #ifndef __ANDROID__ // Layoutlib does not compile HWUIProperties.sysprop as it depends on cutils properties
+ std::optional<bool> use_vulkan() {
+-    return base::GetBoolProperty("ro.hwui.use_vulkan", false);
++    return base::GetBoolProperty("persist.hwui.use_vulkan", false);
+ }
+ 
+ std::optional<std::int32_t> render_ahead() {
+-- 
+2.34.1
+


### PR DESCRIPTION
Mesa3D/v3dv AHB extension support has been landed [1]. It's time to migrate the UI to use Vulkan API.

[1]: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/14195
Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>
Signed-off-by: Michał Gapiński <mike@gapinski.eu>