### PR TITLE
Add instructions for running build_cm4.sh and unfold_aosp.sh scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,30 @@ cd android-raspberry-pi
 ./unfold_aosp.sh && ./build.sh
 ```
 
+### Running `unfold_aosp.sh` script
+
+To run the `unfold_aosp.sh` script, follow these steps:
+
+* Ensure you have the necessary dependencies installed as mentioned in the `README.md` file.
+* Navigate to the root directory of the repository.
+* Run the `unfold_aosp.sh` script to initialize and sync the AOSP tree. This script is located in the root directory of the repository.
+
+The `unfold_aosp.sh` script will handle the rest of the setup process for the AOSP tree.
+
+### Running `build_cm4.sh` script
+
+To run the `build_cm4.sh` script, follow these steps:
+
+* Ensure you have the necessary dependencies installed as mentioned in the `README.md` file.
+* Navigate to the root directory of the repository.
+* Run the `unfold_aosp.sh` script to initialize and sync the AOSP tree. This script is located in the root directory of the repository.
+* Once the AOSP tree is set up, execute the `build_cm4.sh` script by running the following command:
+  ```bash
+  ./build_cm4.sh
+  ```
+
+The `build_cm4.sh` script will handle the rest of the build process for the CM4 target.
+
 ### Notes
 
 - Depending on your hardware and internet connection, downloading and building may take 8h or more.  

--- a/build_cm4.sh
+++ b/build_cm4.sh
@@ -2,6 +2,16 @@
 
 trap 'echo -e "\nbuild.sh interrupted"; exit 1' SIGINT
 
+# Ensure dependencies are installed
+if ! command -v repo &> /dev/null
+then
+    echo "repo could not be found. Please install the necessary dependencies as mentioned in the README.md file."
+    exit 1
+fi
+
+# Navigate to the root directory of the repository
+cd "$(dirname "$0")"
+
 echo Building the Android
 pushd aosptree
 . build/envsetup.sh
@@ -9,3 +19,4 @@ lunch tesla_android_cm4-userdebug
 make images -k || make images -j1
 make sdcard
 make otapackage
+popd

--- a/unfold_aosp.sh
+++ b/unfold_aosp.sh
@@ -2,6 +2,7 @@
 
 LOCAL_PATH=$(pwd)
 
+# Initialize and sync the AOSP repository
 echo Init repo tree using AOSP manifest
 pushd aosptree
 repo init --depth=2 -u https://android.googlesource.com/platform/manifest -b refs/tags/android-platform-14.0.0_r8 ${GD_REPO_INIT_ARGS}
@@ -14,11 +15,13 @@ git add *
 git commit -m "Add GloDroid Project" --no-edit
 popd
 
+# Sync the AOSP repository
 echo Sync repo tree
 pushd aosptree
 repo sync --no-clone-bundle --no-tags -j$(nproc --all) -v
 popd
 
+# Apply patches to the AOSP repository
 echo Patch AOSP tree
 patch_dir() {
     pushd aosptree/$1


### PR DESCRIPTION
Add instructions for running `build_cm4.sh` and `unfold_aosp.sh` scripts in `README.md`.

* **README.md**
  - Add instructions for running `unfold_aosp.sh` script.
  - Add instructions for running `build_cm4.sh` script.

* **build_cm4.sh**
  - Add instructions to ensure dependencies are installed.
  - Add instructions to navigate to the root directory of the repository.

* **unfold_aosp.sh**
  - Add instructions to initialize and sync the AOSP repository.
  - Add instructions to apply patches.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tesla-android/android-raspberry-pi?shareId=XXXX-XXXX-XXXX-XXXX).