### PR TITLE
Bump raspberrypi firmware to 20250430

### DIFF
--- a/manifests/glodroid.xml
+++ b/manifests/glodroid.xml
@@ -45,7 +45,7 @@
   <project path="glodroid/bootloader/u-boot"      remote="github" name="u-boot/u-boot.git"    groups="glodroid" revision="4459ed60cb1e0562bc5b40405e2b4b9bbf766d57" />
 
   <project path="glodroid/bootloader/atf"         name="platform/external/arm-trusted-firmware" groups="glodroid" revision="a127b99d5a063c798d1c6d2e1d4791a630f78355" />
-  <project path="glodroid/bootloader/raspberry-fw"  remote="github"  name="raspberrypi/firmware.git" groups="glodroid" revision="bfbba6aa9ecc16d44c571ad00b4650ae10c939f6" clone-depth="1" />
+  <project path="glodroid/bootloader/raspberry-fw"  remote="github"  name="raspberrypi/firmware.git" groups="glodroid" revision="bc7f439c234e19371115e07b57c366df59cc1bc7" clone-depth="1" />
 
   <!-- kernel/firmware components (platform) -->
   <project path="glodroid/kernel/broadcom"        remote="glodroid" name="glodroid_forks.git" groups="glodroid" revision="refs/tags/kernel-broadcom-2024w25" />


### PR DESCRIPTION
Older firmware release used by Tesla Android conflicts with the current eeprom.

Closes issue #57